### PR TITLE
Ft/clean macos dot files

### DIFF
--- a/simplemenu/output/Bittboy/deploy.sh
+++ b/simplemenu/output/Bittboy/deploy.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 echo "Welcome to Taichi's simplemenu deploy script! Initiating..."
+
+# Preparation: clean 'main' partition - delete all macos dot files 
+echo "Deleting all macos dot files"
+find /mnt/ -name '._*' -exec rm -v {} \;
+echo "Preparation completed"
+
 # Step 0: Copy main.sh to a variable for later use
 if [ -f "/mnt/apps/simplemenu/main.sh" ]; then
     echo "Saving main.sh contents from /mnt/apps/simplemenu/"

--- a/simplemenu/output/Bittboy/deploy.sh
+++ b/simplemenu/output/Bittboy/deploy.sh
@@ -4,7 +4,7 @@ echo "Welcome to Taichi's simplemenu deploy script! Initiating..."
 
 # Preparation: clean 'main' partition - delete all macos dot files 
 echo "Deleting all macos dot files"
-find /mnt/ -name '._*' -exec rm -v {} \;
+find /mnt/ -name '._*' -exec rm -v {} &> /dev/null \;
 echo "Preparation completed"
 
 # Step 0: Copy main.sh to a variable for later use

--- a/simplemenu/output/Bittboy/scripts/autoexec.sh
+++ b/simplemenu/output/Bittboy/scripts/autoexec.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-# If you are planning on connecting the v90's SD Card onto a MacOS device, uncomment the following line:
-#find /mnt/ -name '._*' -exec rm -v {} \;
+find /mnt/.simplemenu -name '._*' -exec rm -v {} \;
 cd /mnt/apps/simplemenu
 ./simplemenu

--- a/simplemenu/output/Bittboy/scripts/autoexec.sh
+++ b/simplemenu/output/Bittboy/scripts/autoexec.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
-find /mnt/.simplemenu -name '._*' -exec rm -v {} \;
+if [ -d "/mnt/.simplemenu" ]; then
+  echo "Cleaning .simplemenu folder"
+  find /mnt/.simplemenu -name '._*' -exec rm -v {} \;
+fi
 cd /mnt/apps/simplemenu
 ./simplemenu


### PR DESCRIPTION
- Clean macos dot files before simplemenu installation (preparation step)
- Clean macos dot files from .simplemenu folder on boot to prevent black screen after copying files in macos